### PR TITLE
Add validator filtering capabilities

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,5 @@
 REACT_APP_API_URL=wss://rpc.xx.network
 REACT_APP_BACKEND_HOST=xxexplorer-prod.hasura.app
 REACT_APP_WALLET_URL=https://wallet.xx.network
+REACT_APP_COMMISSION_FILTER=
+REACT_APP_FILTER_STATIC_LIST_URL=

--- a/package.json
+++ b/package.json
@@ -88,5 +88,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/src/schemas/staking.schema.ts
+++ b/src/schemas/staking.schema.ts
@@ -173,6 +173,29 @@ export const GET_VALIDATOR_STATS = gql`
   }
 `;
 
+export type GetValidatorsPerCommission = {
+  agg: { aggregate: { count: number } }
+  stats: {
+    id: string;
+  }[]
+}
+
+export const GET_VALIDATORS_PER_COMMISSION = gql`
+  query GetValidatorsPerCommission($commission: Float!) {
+    agg: validator_stats_aggregate(
+      where: {commission: {_gte: $commission}}
+      distinct_on: stash_address
+    ) {
+      aggregate {
+        count
+      }
+    }
+    stats: validator_stats(where: {commission: {_gte: $commission}}, distinct_on: stash_address) {
+      id: stash_address
+    }
+  }
+`;
+
 /* -------------------------------------------------------------------------- */
 /*                                Staking Stats                               */
 /* -------------------------------------------------------------------------- */

--- a/src/simple-staking/filters.ts
+++ b/src/simple-staking/filters.ts
@@ -1,0 +1,23 @@
+import { ElectedWithReturn } from './selection';
+
+export const COMMISSION_FILTER = Number(process.env.REACT_APP_COMMISSION_FILTER ?? '100');
+export const FILTER_STATIC_LIST_URL = process.env.REACT_APP_FILTER_STATIC_LIST_URL ?? '';
+
+export const fetchStaticList = async (): Promise<string[]> => {
+  if (!FILTER_STATIC_LIST_URL) {
+    return [];
+  }
+  try {
+    const response = await fetch(FILTER_STATIC_LIST_URL);
+    const text = await response.text();
+    return text.split('\n').map((line) => line.trim()).filter((line) => line.length > 0);
+  } catch (error) {
+    console.error(`Error fetching static list: ${error}`);
+    return [];
+  }
+}
+
+export type ValidatorFilter = (validator: ElectedWithReturn) => boolean;
+export const validatorFilterExcludedList = (list: string[]): ValidatorFilter => (validator: ElectedWithReturn) => !list.includes(validator.validatorId);
+
+export const validatorFilterAllowedList = (list: string[]): ValidatorFilter => (validator: ElectedWithReturn) => list.includes(validator.validatorId);


### PR DESCRIPTION
Filter validators based on ever having been elected with a given commission.
Filter validators based on a static list served from any URL as configured by Foundation.

Both commission and static list can be configured via env.